### PR TITLE
Quick DocFix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -459,7 +459,7 @@ And the output?
 Maybe a more realistic example would be useful. Let's say we want to add
 headers to a Flask response.
 
-.. python::
+.. code:: python
 
 
     from flask import Flask, Response, make_response

--- a/pydecor/_version.py
+++ b/pydecor/_version.py
@@ -8,5 +8,5 @@ and also set as the __version__ attribute for the package.
 
 from __future__ import absolute_import, unicode_literals
 
-__version_info__ = (1, 1, 1)
+__version_info__ = (1, 1, 2)
 __version__ = '.'.join([str(ver) for ver in __version_info__])


### PR DESCRIPTION
Apparently you can't adjust the description in the PyPI interface anymore because they have retired the legacy endpoint that the interface uses, and I can't find a way to edit in the new one. So, a patch version it is.