### PR TITLE
Convert to ReadTheDocs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,3 +36,17 @@ Memoization, prep for v 2.0
 -----
 
 * fixed setup to pull README once more, even in Python 2
+
+1.1.2
+-----
+
+* fixed an issue with the README
+
+1.1.3
+-----
+
+Apparently `pythonhosted.org` has been deprecated, so I set up a
+Read the Docs account and moved the documentation there.
+
+* Uploaded README to point to new docs
+* Added docs build image for funsies.

--- a/README.rst
+++ b/README.rst
@@ -4,11 +4,14 @@ PyDecor
 .. image:: https://travis-ci.org/mplanchard/pydecor.svg?branch=master
    :target: https://travis-ci.org/mplanchard/pydecor
 
+.. image:: https://readthedocs.org/projects/pydecor/badge/?version=latest
+    :target: https://pydecor.readthedocs.io/
+
 Easy-peasy Python decorators!
 
 * GitHub: https://github.com/mplanchard/pydecor
 * PyPI: https://pypi.python.org/pypi/pydecor
-* Docs: https://pythonhosted.org/pydecor/
+* Docs: https://pydecor.readthedocs.io/
 * Contact: ``msplanchard`` ``@`` ``gmail`` or @msplanchard on Twitter
 
 
@@ -1028,9 +1031,9 @@ Credits and Links
 .. _`pep 484`: https://www.python.org/dev/peps/pep-0484/
 .. _six: https://pythonhosted.org/six/
 .. _`typing backport`: https://pypi.org/project/typing/
-.. _docs: https://pythonhosted.org/pydecor/#
+.. _docs: https://pydecor.readthedocs.io/en/latest/
 .. _`decorator module docs`:
-    https://pythonhosted.org/pydecor/pydecor.decorators.html
+    https://pydecor.readthedocs.io/en/latest/pydecor.decorators.html
 .. _issues: https://github.com/mplanchard/pydecor/issues
 .. _PRs: https://github.com/mplanchard/pydecor/pulls
 .. _dill: https://pypi.python.org/pypi/dill

--- a/pydecor/_version.py
+++ b/pydecor/_version.py
@@ -8,5 +8,5 @@ and also set as the __version__ attribute for the package.
 
 from __future__ import absolute_import, unicode_literals
 
-__version_info__ = (1, 1, 2)
+__version_info__ = (1, 1, 3)
 __version__ = '.'.join([str(ver) for ver in __version_info__])


### PR DESCRIPTION
Just discovered `pythonhosted` was deprecated and gone
from the PyPI UI, so switching to ReadTheDocs.