### PR TITLE
Minor repository improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,18 +1,22 @@
 root = true
 
+[*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{py}]
+[*.py]
 indent_style = space
 indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{js,html,css,scss,json,ini,yml,yaml,rst}]
+[*.{js,html,css,scss,json,ini,yml,yaml}]
 indent_style = space
 indent_size = 2
 
+[*.rst]
+indent_style = space
+indent_size = 3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+version: 2
+
+submodules:
+  include: []
+
+build:
+  image: latest
+
+python:
+  version: 3.7
+  install:
+    - requirements: doc/requirements.txt
+
+sphinx:
+  builder: html
+  configuration: doc/conf.py
+
+formats: []
+#  - htmlzip
+  - pdf
+#  - epub

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+-r ../requirements.txt
+sphinx
+sphinx-autodoc-typehints

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 coverage
 ipdb
 mock;python_version<"3.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,4 @@ ipdb
 mock;python_version<"3.0"
 pytest
 pytest-cov
-sphinx
-sphinx-autodoc-typehints
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ setenv =
 
 commands =
   pip install -r requirements-dev.txt
-  pip install -r requirements.txt
   coverage run --source {env:PACKAGE_NAME:} -m py.test {posargs}
   coverage report
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,7 @@ setenv =
   PACKAGE_NAME = pydecor
 
 commands =
-  pip install -r requirements-dev.txt
-  pip install -r requirements.txt
+  pip install -r docs/requirements.txt
   sphinx-apidoc -o docs {env:PACKAGE_NAME:} --separate --private -f
   make text --directory=docs
   make html --directory=docs


### PR DESCRIPTION
This adds some minor improvements:

* extracted documentation dependencies, so less packages need to be installed on ReadTheDocs
  * new `requirements.txt` in `docs/` (this will be recognized by GitHub dependency scanning as well as other services)
  * made this file recursively call the main requirements file
  * added a ReadTheDocs configuration file
* made developers requirements load recursively main requirements file
* fixed .editorconfig