### PR TITLE
Added the PyPI release provider to Travis settings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
-# Travis file for CI testing
----
-
 language: python
 python:
   - "3.6"
-install: pip install tox
-script: tox
+
+install:
+  - pip3 install -U tox
+
+script:
+  - tox
+
+deploy:
+  provider: pypi
+  user: "__token__"
+  password: $PYPI_TOKEN
+  distributions: "sdist bdist_wheel"
+  skip_existing: true
+  on:
+    tags: true


### PR DESCRIPTION
This adds a release provider for PyPI.

Travis rules:
- every push is build
  - currently it uses tox
- every taged push is in addition released to PyPI

To get this running:
1. Create a private access token at PyPI with limited access rights to the `pydecos` package project.
2. Create a secret at Travis for the `mplanchard/pydecor` repository and name it `PYPI_TOKEN`

Solves #7.