### PR TITLE
MAINT: update supported python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 # Travis file for CI testing
 ---
-
 language: python
+
 python:
-  - "3.6"
-install: pip install tox
-script: tox
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
+  - pypy3
+
+install:
+  - pip install -U tox tox-travis
+
+script:
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py36, docs
+envlist = py35, py36, py37, py38, pypy3, docs
 
 [testenv]
 


### PR DESCRIPTION
Drops testing for EoL'ed Pythons 2.7 and 3.4. Adds explicit testing for Python 3.5+

Also switches to using `tox-travis` to specify a build matrix in Travis, rather than relying on the build env having all of our necessary pythons available.