### PR TITLE
Move to new generic syntax; remove old things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,6 @@ jobs:
     - stage: lint
       script: make lint
       python: "3.8"
-    # For some reason, the py35 environment in Travis consistently gets
-    # killed when running `make test`, but not when running tox directly.
-    # So, we manually specify the test run for that environment.
-    - stage: test
-      script:
-        - pip install tox
-        - tox -e py35
-      python: "3.5"
     - stage: deploy
       script: skip
       python: "3.8"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "editor.formatOnSave": true,
+  "markdown.extension.toc.githubCompatibility": true,
+
+  "python.formatting.provider": "black",
+  "python.formatting.blackArgs": ["--line-length", "80"],
+
+  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Args": [],
+  "python.linting.pydocstyleEnabled": true,
+  "python.linting.pydocstyleArgs": [],
+  "python.linting.pylintEnabled": true,
+  "python.linting.pylintArgs": [],
+  "python.linting.mypyEnabled": true,
+  "python.linting.mypyArgs": [],
+
+  "python.pythonPath": "venv/bin/python",
+  "restructuredtext.confPath": ""
+}

--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,6 @@ test: venv
 tox: venv
 	TOXENV=$(TOXENV) tox
 
-test-3.5:
-	docker run --rm -it --mount type=bind,source="$(PWD)",target="/src" -w "/src" \
-		python:3.5 bash -c "make clean && pip install -e .[dev] && $(TEST); make clean"
-
 test-3.6:
 	docker run --rm -it --mount type=bind,source="$(PWD)",target="/src" -w "/src" \
 		python:3.6 bash -c "make clean && pip install -e .[dev] && $(TEST); make clean"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ SRC_FILES = *.py $(PKG_DIR) $(TEST_DIR)
 TEST = pytest \
 	--cov-config=setup.cfg \
 	--cov=$(PKG_NAME) \
+	--cov-report=term \
+	--cov-report=xml:coverage.xml \
 	--doctest-modules \
 	$(PKG_DIR) \
 	$(TEST_DIR)
@@ -76,10 +78,10 @@ fmt: venv
 
 lint: venv
 	$(VENV) black --check $(SRC_FILES)
+	$(VENV) flake8 $(SRC_FILES)
+	$(VENV) mypy $(SRC_FILES)
+	$(VENV) pylint --errors-only $(SRC_FILES)
 	# $(VENV) pydocstyle $(SRC_FILES)
-	# $(VENV) flake8 $(SRC_FILES)
-	# $(VENV) pylint --errors-only $(SRC_FILES)
-	# $(VENV) mypy $(SRC_FILES)
 
 setup: venv-clean venv
 
@@ -89,20 +91,20 @@ test: venv
 tox: venv
 	TOXENV=$(TOXENV) tox
 
-test-3.6:
+test-docker-3.6:
 	docker run --rm -it --mount type=bind,source="$(PWD)",target="/src" -w "/src" \
 		python:3.6 bash -c "make clean && pip install -e .[dev] && $(TEST); make clean"
 
-test-3.7:
+test-docker-3.7:
 	docker run --rm -it --mount type=bind,source="$(PWD)",target="/src" -w "/src" \
 		python:3.7 bash -c "make clean && pip install -e .[dev] && $(TEST); make clean"
 
-test-3.8:
+test-docker-3.8:
 	docker run --rm -it --mount type=bind,source="$(PWD)",target="/src" -w "/src" \
 		python:3.8 bash -c "make clean && pip install -e .[dev] && $(TEST); make clean"
 
-test-pypy3:
+test-docker-pypy:
 	docker run --rm -it --mount type=bind,source="$(PWD)",target="/src" -w "/src" \
 		pypy:3 bash -c "make clean && pip install -e .[dev] && $(TEST); make clean"
 
-test-all-versions: test-3.5 test-3.6 test-3.7 test-3.8 test-pypy3
+test-docker: test-docker-3.6 test-docker-3.7 test-docker-3.8 test-docker-pypy3

--- a/README.rst
+++ b/README.rst
@@ -337,7 +337,28 @@ Generics
 * ``construct_decorator`` - specify functions to be run ``before``, ``after``,
   or ``instead`` of decorated functions. Returns a reusable decorator.
 
-Every generic decorator takes any number of keyword arguments, which will be
+The callable passed to a generic decorator is expected to handle at least one
+positional argument, which will be an instance of `Decorated`. `Decorated`
+objects provide the following interface:
+
+**Attributes:**
+
+* `args`: a tuple of any positional arguments with which the decorated
+  callable was called
+* `kwargs`: a dict of any keyword arguments with which the decorated
+  callable was called
+* `wrapped`: a reference to the decorated callable
+* `result`: when the _wrapped_ function has been called, its return value is
+  stored here
+
+**Methods**
+
+* `__call__(*args, **kwargs)`: a shortcut to
+  `decorated.wrapped(*args, **kwargs)`, calling an instance of `Decorated`
+  calls the underlying wrapped callable. The result of this call (or a
+  direct call to `decorated.wrapped()`) will set the `result` attribute.
+
+Every generic decorator may take any number of keyword arguments, which will be
 passed directly into the provided callable, so, running the code below prints
 "red":
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,14 @@
 -r requirements.txt
+
+# Linting/dev requirements: these are not necessary for Pypy, b/c we don't
+# run linting with it, and it's a pain to install things on in CI.
 black;python_version>"3.5" and implementation_name=="cpython"
+flake8;implementation_name=="cpython"
+ipdb;implementation_name=="cpython"
+mypy;implementation_name=="cpython"
+pylint;implementation_name=="cpython"
+
 coverage
-ipdb
 mock;python_version<"3.0"
 pytest
 pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,27 @@ source = pydecor
 [flake8]
 max-line-length = 80
 
+[mypy]
+check_untyped_defs = True
+follow_imports = silent
+ignore_missing_imports = True
+show_column_numbers = True
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+disallow_untyped_decorators = True
+strict_optional = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_ignores = True
+
+[mypy-tests.*]
+disallow_untyped_decorators = False
+
+[pydocstyle]
+add-ignore = D202, D203, D213, D400, D413
+
 [tool:pytest]
 norecursedirs = .* build dist CVS _darcs {arch} .*egg venv
 junit_family=xunit2
 junit_xml=.pytest.xml
-cov_report=
-    term
-    xml:.coverage.xml

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 setup module for ihiji_schemas
 """
 
+import typing as t
 from os.path import dirname, join, realpath
 from setuptools import setup, find_packages
 from sys import version_info
@@ -30,10 +31,10 @@ KEYWORDS = ["decorators", "python3"]
 
 
 PACKAGE_DEPENDENCIES = []
-SETUP_DEPENDENCIES = []
+SETUP_DEPENDENCIES: t.List[str] = []
 TEST_DEPENDENCIES = []
 
-ENTRY_POINTS = {}
+ENTRY_POINTS: dict = {}
 
 
 with open(join(fdir, "requirements.txt")) as reqfile:

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,10 @@ CLASSIFIERS = [
     "Operating System :: POSIX :: Linux",
     # "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    # 'Programming Language :: Python :: Implementation :: PyPy',
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
 
@@ -101,6 +104,7 @@ setup(
     keywords=KEYWORDS,
     package_dir={"": "src"},
     packages=find_packages(where="src"),
+    python_requires=">=3.6",
     install_requires=PACKAGE_DEPENDENCIES,
     setup_requires=SETUP_DEPENDENCIES,
     tests_require=TEST_DEPENDENCIES,

--- a/src/pydecor/_version.py
+++ b/src/pydecor/_version.py
@@ -8,5 +8,5 @@ and also set as the __version__ attribute for the package.
 
 from __future__ import absolute_import, unicode_literals
 
-__version_info__ = (1, 1, 3)
+__version_info__ = (2, 0, 0)
 __version__ = ".".join([str(ver) for ver in __version_info__])

--- a/src/pydecor/caches.py
+++ b/src/pydecor/caches.py
@@ -37,13 +37,13 @@ class LRUCache(OrderedDict):
     def __getitem__(self, key, **kwargs):
         value = OrderedDict.__getitem__(self, key)
         del self[key]
-        OrderedDict.__setitem__(self, key, value, **kwargs)
+        OrderedDict.__setitem__(self, key, value, **kwargs)  # type: ignore
         return value
 
     def __setitem__(self, key, value, **kwargs):
         if key in self:
             del self[key]
-        OrderedDict.__setitem__(self, key, value, **kwargs)
+        OrderedDict.__setitem__(self, key, value, **kwargs)  # type: ignore
         if self._max_size and len(self) > self._max_size:
             self.popitem(last=False)
 

--- a/src/pydecor/decorators/__init__.py
+++ b/src/pydecor/decorators/__init__.py
@@ -8,14 +8,25 @@ __all__ = (
     "before",
     "construct_decorator",
     "decorate",
+    "export",
     "instead",
     "Decorated",
-    "DecoratorType",
     "intercept",
     "log_call",
     "memoize",
-    "export",
 )
 
-from .generic import *
-from .ready_to_wear import *
+from .generic import (
+    after,
+    before,
+    construct_decorator,
+    decorate,
+    Decorated,
+    instead,
+)
+from .ready_to_wear import (
+    export,
+    intercept,
+    log_call,
+    memoize,
+)

--- a/src/pydecor/decorators/_utility.py
+++ b/src/pydecor/decorators/_utility.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, unicode_literals
 __all__ = ("ClassWrapper",)
 
 
-from functools import partial, wraps
+from functools import partial
 from inspect import isclass
 from logging import getLogger
 from sys import version_info
@@ -24,7 +24,7 @@ PY2 = version_info < (3, 0)
 
 
 def get_fn_args(decorated, args):
-    """Strip "self" and "cls" variables from args
+    """Strip "self" and "cls" variables from args.
 
     For now, this avoids assuming that the "self" variable is called
     "self" on instance methods, although if this winds up being
@@ -33,7 +33,9 @@ def get_fn_args(decorated, args):
     isn't called "self" won't have their "self" argument stripped.
     """
     fn_args = args
-    decor_name = decorated.__name__
+    decor_name = (
+        decorated.__name__ if hasattr(decorated, "__name__") else str(decorated)
+    )
 
     # Check if the wrapped function is an attribute on args[0]
     if args and decor_name in dir(args[0]):
@@ -108,7 +110,7 @@ class ClassWrapper(object):
     __decoropts__ = None
 
     def __init__(self, *args, **kwargs):
-        self.__wrapped__ = self.__wrapped__(*args, **kwargs)
+        self.__wrapped__ = self.__wrapped__(*args, **kwargs)  # type: ignore
 
     def __getattribute__(self, item):
 
@@ -169,7 +171,7 @@ class ClassWrapper(object):
             {
                 "__wrapped__": wrapped,
                 "__decorator__": decorator,
-                "__decoropts__": {
+                "__decoropts__": {  # type: ignore
                     "instance_methods_only": instance_methods_only
                 },
             }

--- a/src/pydecor/decorators/_visibility.py
+++ b/src/pydecor/decorators/_visibility.py
@@ -7,9 +7,13 @@ __all__ = ("export",)
 __api__ = __all__
 
 import sys
+import typing as t
 
 
-def export(entity):
+T = t.TypeVar("T", bound=t.Callable)
+
+
+def export(entity: T) -> T:
     """Register the given function or class as publicly accessible in a module.
 
     Creates or updates the `__all__` attribute in the module in which the
@@ -82,11 +86,11 @@ def export(entity):
             ).format(entity.__module__)
         )
     if hasattr(module, "__all__"):
-        if entity.__name__ not in module.__all__:
-            module.__all__ = module.__all__.__class__(
-                (*module.__all__, entity.__name__)
+        if entity.__name__ not in module.__all__:  # type: ignore
+            module.__all__ = module.__all__.__class__(  # type: ignore
+                (*module.__all__, entity.__name__)  # type: ignore
             )
     else:
-        module.__all__ = [entity.__name__]
+        module.__all__ = [entity.__name__]  # type: ignore
 
     return entity

--- a/src/pydecor/decorators/generic.py
+++ b/src/pydecor/decorators/generic.py
@@ -24,6 +24,7 @@ __all__ = (
 )
 
 
+import typing as t
 from inspect import isclass
 from logging import getLogger
 from functools import partial, wraps
@@ -40,7 +41,7 @@ DecoratorType = Union[FunctionType, MethodType, type]
 
 
 class Decorated(object):
-    """A representation of a decorated class
+    """A representation of a decorated class.
 
     This user-immutable object provides information about the decorated
     class, method, or function. The decorated callable can be called
@@ -100,6 +101,11 @@ class Decorated(object):
 
     __slots__ = ("args", "kwargs", "wrapped", "result")
 
+    args: tuple
+    kwargs: dict
+    wrapped: t.Callable
+    result: t.Optional[t.Any]
+
     def __init__(self, wrapped, args, kwargs, result=None):
         """Instantiate a Decorated object
 
@@ -153,135 +159,55 @@ class Decorated(object):
 
 
 def before(
-    func,
-    pass_params=False,
-    pass_decorated=False,
-    implicit_method_decoration=True,
-    instance_methods_only=False,
-    unpack_extras=True,
-    extras_key="extras",
-    _use_future_syntax=False,
-    **extras
+    func, implicit_method_decoration=True, instance_methods_only=False, **extras
 ):
-    """Specify a callable to be run before the decorated resource
+    """Specify a callable to be run before the decorated resource.
 
     A callable provided to this decorator will be called
-    any time the decorated function is executed, immediately before
+    any time the decorated function is executed, immediately _before_
     its execution.
 
     The callable is expected to either return ``None`` or to return
     a tuple and dict with which to replace the arguments to the
     decorated function.
 
-    By default, the provided callable is called with no arguments
-    and only any keyword arguments provided as extras to the
-    decoration call::
-
-        (**extras)
-
-    However, this is configurable. If all possible ``pass``
-    parameters are True, the call signature would look like this::
-
-        (decorated_args, decorated_kwargs, decorated, **extras)
-
-    Items that are omitted will be removed from the call signature.
-    For example, specifying ``pass_params=False`` and
-    ``pass_decorated=True`` would adjust the call signature to
-    look like::
-
-        (decorated, **extras)
-
-    Specifying ``pass_params=True`` will pass the arguments and
-    keyword arguments of the decorated function (as a tuple and
-    a dict, respectively) to the provided callable.
-
-    Specifying ``pass_decorated=True`` will pass a reference
-    to the decorated function to the provided callable.
-
-    Any extra keyword arguments passed to the decoration call
-    will by default be passed directly as keyword arguments
-    to ``func``. If keyword names conflict with the passed
-    function, ``unpack_extras=False`` will cause extra keyword
-    arguments to be passed as a dictionary using the value
-    of ``extras_key``, which defaults to ``"extras"``.
+    The callable is called with an instance of :any:`Decorated` as
+    its first positional argument. Any kwargs provided to `before()`
+    are also passed to the callable.
 
     :param Callable func:
-        a callable to run before the decorated function. By default,
-        it is called with no arguments, but the call signature may
-        be changed depending on the value of ``pass_params`` and
-        ``pass_decorated``
-
-    :param bool pass_params:
-        (default False) if True, the arguments and keyword arguments to
-        the decorated function will be passed to ``func`` as a tuple
-        and a dict, respectively
-
-    :param bool pass_decorated:
-        (default False) if True, a reference to the decorated function
-        will be passed to the provided ``func``
+        a callable to run before the decorated function. It is called
+        with an instance of :any:`Decorated` as its first argument. In
+        addition, any keyword arguments provided to `before` are passed
+        through to the callable.
 
     :param bool implicit_method_decoration:
         (default True) if True, decorating a class implies decorating
-        all of its methods
+        all of its methods. Otherwise, the decorator will be called
+        when the class is instantiated.
 
     :param bool instance_methods_only:
         (default False) if True, decorating a class implies decorating
         only its instance methods (not ``classmethod``- or
         ``staticmethod``- decorated methods)
 
-    :param bool unpack_extras:
-        (default True) if True, any extra keyword arguments included
-        in the decorator call will be passed as keyword arguments
-        to ``func``. If ``False``, extra keyword arguments will be
-        passed to func as a dict assigned to the keyword argument
-        corresponding to ``key``
-
-    :param str extras_key:
-        (default ``"extras"``) the key to which to assign extra
-        decorator keyword arguments when ``unpack_extras`` is ``False``
-
-    :param bool _use_future_syntax:
-        (default False) if True, use the new ``Decorated`` object,
-        which will become the default in version 2.0.0. If this
-        parameter is True, all other parameters will be ignored
-        expect for ``instance_methods_only`` and
-        ``implicit_method_decoration``, a ``Decorated`` object
-        will be passed to the function as its first argument,
-        and any provided keyword arguments will be unpacked.
-
     :param **dict extras:
-        any extra keyword arguments supplied to the decoration call
+        any extra keyword arguments supplied to the decoration call,
+        which will be passed directly to the provided callable.
 
     :return: the decorated function/method/class
     :rtype: Union[FunctionType,MethodType,type]
     """
 
     def decorator(decorated):
-        """The function that returns a replacement for the original"""
+        """Return a decorated function."""
 
         def wrapper(*args, **kwargs):
-            """The function that replaces the decorated one"""
-
-            if unpack_extras or _use_future_syntax:
-                fkwargs = extras
-            else:
-                fkwargs = {extras_key: extras}
-
+            """Call the before and decorated functions."""
             fn = func
-            decor = decorated
 
-            if _use_future_syntax:
-                decor = Decorated(decorated, args, kwargs)
-                fn = partial(fn, decor)
-            else:
-                if pass_params:
-                    fn_args = get_fn_args(decorated, args)
-                    fn = partial(fn, fn_args, kwargs)
-
-                if pass_decorated:
-                    fn = partial(fn, decorated)
-
-            fret = fn(**fkwargs)
+            decor = Decorated(decorated, args, kwargs)
+            fret = fn(decor, **extras)
 
             if fret is not None:
                 args, kwargs = fret
@@ -303,113 +229,40 @@ def before(
 
 
 def after(
-    func,
-    pass_params=False,
-    pass_result=True,
-    pass_decorated=False,
-    implicit_method_decoration=True,
-    instance_methods_only=False,
-    unpack_extras=True,
-    extras_key="extras",
-    _use_future_syntax=False,
-    **extras
+    func, implicit_method_decoration=True, instance_methods_only=False, **extras
 ):
-    """Specify a callable to be run after the decorated resource
+    """Specify a callable to be run after the decorated resource.
 
     A callable provided to this decorator will be called
-    any time the decorated function is executed, immediately after
+    any time the decorated function is executed, immediately _after_
     its execution.
 
     If the callable returns a value, that value will replace the
     return value of the decorated function.
 
-    By default, the provided callable is called with the return from
-    the decorated function as its first argument and only any
-    keyword arguments provided as extras to the decoration call::
-
-        (decorated_result, **extras)
-
-    However, this is configurable. If all possible ``pass``
-    parameters are True, the call signature would look like this::
-
-        (decorated_result, decorated_args,
-         decorated_kwargs, decorated, **extras)
-
-    Items that are omitted will be removed from the call signature.
-    For example, specifying ``pass_params=False`` and
-    ``pass_decorated=True`` would adjust the call signature to
-    look like::
-
-        (decorated_result, decorated, **extras)
-
-    Specifying ``pass_result=False`` will prevent the result
-    from being passed to the callable.
-
-    Specifying ``pass_params=True`` will pass the arguments and
-    keyword arguments (as a tuple and a dict) to the decorated
-    function as the second and third arguments, respectively.
-
-    Specifying ``pass_decorated=True`` will pass a reference
-    to the decorated function as the second argument, or the
-    fourth argument if ``pass_params=True``
-
-    Any extra keyword arguments passed to the decoration call
-    will by default be passed directly as keyword arguments
-    to ``func``. If keyword names conflict with the passed
-    function, ``unpack_extras=False`` will cause extra keyword
-    arguments to be passed as a dictionary using the value
-    of ``extras_key``, which defaults to ``"extras"``.
+    The callable is called with an instance of :any:`Decorated` as
+    its first positional argument. Any kwargs provided to `after()`
+    are also passed to the callable.
 
     :param Callable func:
-        a callable to run after the decorated function. By default,
-        it is called with the result of the decorated function as
-        its only argument, but the call signature may be changed
-        depending on the value of ``pass_params`` and ``pass_decorated``
-
-    :param bool pass_result:
-        (default True) if True, the return from the decorated
-        function will be passed to the provided callable
-
-    :param bool pass_params:
-        (default False) if True, the arguments and keyword arguments to
-        the decorated function will be passed to ``func`` as a tuple
-        and a dict, respectively
-
-    :param bool pass_decorated:
-        (default False) if True, a reference to the decorated function
-        will be passed to the provided ``func``
+        a callable to run after the decorated function. It is called
+        with an instance of :any:`Decorated` as its first argument. In
+        addition, any keyword arguments provided to `before` are passed
+        through to the callable.
 
     :param bool implicit_method_decoration:
         (default True) if True, decorating a class implies decorating
-        all of its methods
+        all of its methods. Otherwise, the decorator will be called
+        when the class is instantiated.
 
     :param bool instance_methods_only:
         (default False) if True, decorating a class implies decorating
         only its instance methods (not ``classmethod``- or
         ``staticmethod``- decorated methods)
 
-    :param bool unpack_extras:
-        (default True) if True, any extra keyword arguments included
-        in the decorator call will be passed as keyword arguments
-        to ``func``. If ``False``, extra keyword arguments will be
-        passed to func as a dict assigned to the keyword argument
-        corresponding to ``key``
-
-    :param str extras_key:
-        (default ``"extras"``) the key to which to assign extra
-        decorator keyword arguments when ``unpack_extras`` is ``False``
-
-    :param bool _use_future_syntax:
-        (default False) if True, use the new ``Decorated`` object,
-        which will become the default in version 2.0.0. If this
-        parameter is True, all other parameters will be ignored
-        expect for ``instance_methods_only`` and
-        ``implicit_method_decoration``, a ``Decorated`` object
-        will be passed to the function as its first argument,
-        and any provided keyword arguments will be unpacked.
-
     :param **dict extras:
-        any extra keyword arguments supplied to the decoration call
+        any extra keyword arguments supplied to the decoration call,
+        which will be passed directly to the provided callable.
 
     :return: the decorated function/method/class
     :rtype: Union[FunctionType,MethodType,type]
@@ -420,40 +273,14 @@ def after(
 
         def wrapper(*args, **kwargs):
             """The function that replaces the decorated one"""
-
-            decor = decorated
-
-            if _use_future_syntax:
-                decor = Decorated(decorated, args, kwargs)
-
-            ret = decor(*args, **kwargs)
-
-            fn = func
-
-            if _use_future_syntax:
-                fn = partial(fn, decor)
-            else:
-                if pass_result:
-                    fn = partial(fn, ret)
-
-                if pass_params:
-                    fn_args = get_fn_args(decorated, args)
-                    fn = partial(fn, fn_args, kwargs)
-
-                if pass_decorated:
-                    fn = partial(fn, decorated)
-
-            if unpack_extras or _use_future_syntax:
-                fkwargs = extras
-            else:
-                fkwargs = {extras_key: extras}
-
-            fret = fn(**fkwargs)
+            decor = Decorated(decorated, args, kwargs)
+            orig_ret = decor(*args, **kwargs)
+            fret = func(decor, **extras)
 
             if fret is not None:
                 return fret
 
-            return ret
+            return orig_ret
 
         if implicit_method_decoration and isclass(decorated):
             return ClassWrapper.wrap(
@@ -469,17 +296,9 @@ def after(
 
 
 def instead(
-    func,
-    pass_params=True,
-    pass_decorated=True,
-    implicit_method_decoration=True,
-    instance_methods_only=False,
-    unpack_extras=True,
-    extras_key="extras",
-    _use_future_syntax=False,
-    **extras
+    func, implicit_method_decoration=True, instance_methods_only=False, **extras
 ):
-    """Specify a callable to be run in hte place of the decorated resource
+    """Specify a callable to be run in the place of the decorated resource.
 
     A callable provided to this decorator will be called any time the
     decorated function is executed. The decorated function **will not**
@@ -488,73 +307,29 @@ def instead(
     Whatever the provided callable returns is the return value of the
     decorated function.
 
-    By default, the provided callable is called with the arguments
-    and keyword arguments used to call the decorated function, as a
-    tuple and a dict, respectively, and a reference to the decorated
-    function. Any extra keyword arguments specified in the decoration
-    call are also passed to the callable::
-
-        (decorated_args, decorated_kwargs, decorated, **extras)
-
-    Items that are omitted will be removed from the call signature.
-    For example, specifying ``pass_params=False`` would adjust the
-    call signature to look like::
-
-        (decorated, **extras)
-
-    Any extra keyword arguments passed to the decoration call
-    will by default be passed directly as keyword arguments
-    to ``func``. If keyword names conflict with the passed
-    function, ``unpack_extras=False`` will cause extra keyword
-    arguments to be passed as a dictionary using the value
-    of ``extras_key``, which defaults to ``"extras"``.
+    The callable is called with an instance of :any:`Decorated` as
+    its first positional argument. Any kwargs provided to `instead()`
+    are also passed to the callable.
 
     :param Callable func:
-        a callable to run in place of the decorated function. By
-        default, it is called the decorated function's arguments
-        as a tuple, keyword arguments as a dict, and a reference
-        to the decorated function
-
-    :param bool pass_params:
-        (default False) if True, the arguments and keyword arguments to
-        the decorated function will be passed to ``func`` as a tuple
-        and a dict, respectively
-
-    :param bool pass_decorated:
-        (default False) if True, a reference to the decorated function
-        will be passed to the provided ``func``
+        a callable to run in place of the decorated function. It is called
+        with an instance of :any:`Decorated` as its first argument. In
+        addition, any keyword arguments provided to `before` are passed
+        through to the callable.
 
     :param bool implicit_method_decoration:
         (default True) if True, decorating a class implies decorating
-        all of its methods
+        all of its methods. Otherwise, the decorator will be called
+        when the class is instantiated.
 
     :param bool instance_methods_only:
         (default False) if True, decorating a class implies decorating
         only its instance methods (not ``classmethod``- or
         ``staticmethod``- decorated methods)
 
-    :param bool unpack_extras:
-        (default True) if True, any extra keyword arguments included
-        in the decorator call will be passed as keyword arguments
-        to ``func``. If ``False``, extra keyword arguments will be
-        passed to func as a dict assigned to the keyword argument
-        corresponding to ``key``
-
-    :param str extras_key:
-        (default ``"extras"``) the key to which to assign extra
-        decorator keyword arguments when ``unpack_extras`` is ``False``
-
-    :param bool _use_future_syntax:
-        (default False) if True, use the new ``Decorated`` object,
-        which will become the default in version 2.0.0. If this
-        parameter is True, all other parameters will be ignored
-        expect for ``instance_methods_only`` and
-        ``implicit_method_decoration``, a ``Decorated`` object
-        will be passed to the function as its first argument,
-        and any provided keyword arguments will be unpacked.
-
     :param **dict extras:
-        any extra keyword arguments supplied to the decoration call
+        any extra keyword arguments supplied to the decoration call,
+        which will be passed directly to the provided callable.
 
     :return: the decorated function/method/class
     :rtype: Union[FunctionType,MethodType,type]
@@ -565,26 +340,8 @@ def instead(
 
         def wrapper(*args, **kwargs):
             """The function that replaces the decorated one"""
-
-            fn = func
-
-            if _use_future_syntax:
-                decor = Decorated(decorated, args, kwargs)
-                fn = partial(fn, decor)
-            else:
-                if pass_params:
-                    fn_args = get_fn_args(decorated, args)
-                    fn = partial(fn, fn_args, kwargs)
-
-                if pass_decorated:
-                    fn = partial(fn, decorated)
-
-            if unpack_extras or _use_future_syntax:
-                fkwargs = extras
-            else:
-                fkwargs = {extras_key: extras}
-
-            return fn(**fkwargs)
+            decor = Decorated(decorated, args, kwargs)
+            return func(decor, **extras)
 
         if implicit_method_decoration and isclass(decorated):
             return ClassWrapper.wrap(
@@ -608,12 +365,9 @@ def decorate(
     instead_opts=None,
     implicit_method_decoration=True,
     instance_methods_only=False,
-    unpack_extras=True,
-    _use_future_syntax=False,
-    extras_key="extras",
     **extras
 ):
-    """A decorator that combines before, after, and instead decoration
+    """A decorator that combines before, after, and instead decoration.
 
     The ``before``, ``after``, and ``instead`` decorators are all
     stackable, but this decorator provides a straightforward interface
@@ -639,29 +393,28 @@ def decorate(
     is being applied to which methods.
 
     You may specify decorator-specific extras in the various ``opts``
-    dictionaries. In addition, any extra keyword arguments passed
-    to this decorator will be passed to each of the provided
-    callables. As with the individual decorators, if
-    ``unpack_extras=False`` is provided, the extras will be packed
-    into a dict and passed via the ``extras_key`` keyword argument.
+    dictionaries. These will be passed to the provided callables in
+    addition to any keyword arguments supplied to the call to
+    `decorate()`. If there is a naming conflict, the latter override
+    the former.
 
     :param Callable before:
-        a callable to run before the decorated function. By default,
-        it is called with no arguments, but the call signature may
-        be changed depending on the value of ``pass_params`` and
-        ``pass_decorated``
+        a callable to run before the decorated function. It is called
+        with an instance of :any:`Decorated` as its first argument. In
+        addition, any keyword arguments provided to `before` are passed
+        through to the callable.
 
     :param Callable after:
-        a callable to run after the decorated function. By default,
-        it is called with the result of the decorated function as
-        its only argument, but the call signature may be changed
-        depending on the value of ``pass_params`` and ``pass_decorated``
+        a callable to run after the decorated function. It is called
+        with an instance of :any:`Decorated` as its first argument. In
+        addition, any keyword arguments provided to `before` are passed
+        through to the callable.
 
     :param Callable instead:
-        a callable to run in place of the decorated function. By
-        default, it is called the decorated function's arguments
-        as a tuple, keyword arguments as a dict, and a reference
-        to the decorated function
+        a callable to run in place of the decorated function. It is called
+        with an instance of :any:`Decorated` as its first argument. In
+        addition, any keyword arguments provided to `before` are passed
+        through to the callable.
 
     :param dict before_opts:
         a dictionary of keyword arguments to pass to the ``before``
@@ -678,7 +431,8 @@ def decorate(
     :param bool implicit_method_decoration:
         (default True) if True, decorating a class implies decorating
         all of its methods. This value overrides any values set in
-        the various ``opts`` dictionaries.
+        the various ``opts`` dictionaries. If False, the decorator(s)
+        will be called when the class is instantiated.
 
     :param bool instance_methods_only:
         (default False) if True, decorating a class implies decorating
@@ -686,31 +440,10 @@ def decorate(
         ``staticmethod``- decorated methods). This value overrides
         any values set in the various ``opts`` dictionaries.
 
-    :param bool unpack_extras:
-        (default True) if True, any extra keyword arguments included
-        in the decorator call will be passed as keyword arguments
-        to ``func``. If ``False``, extra keyword arguments will be
-        passed to func as a dict assigned to the keyword argument
-        corresponding to ``key``. If provided, this value serves
-        as the default for the various decorators.
-
-    :param str extras_key:
-        (default ``"extras"``) the key to which to assign extra
-        decorator keyword arguments when ``unpack_extras`` is
-        ``False``. If provided, this key serves as the default
-        for the various decorators.
-
-    :param bool _use_future_syntax:
-        (default False) if True, use the new ``Decorated`` object,
-        which will become the default in version 2.0.0. If this
-        parameter is True, all other parameters will be ignored
-        expect for ``instance_methods_only`` and
-        ``implicit_method_decoration``, a ``Decorated`` object
-        will be passed to the function as its first argument,
-        and any provided keyword arguments will be unpacked.
-
     :param **dict extras:
-        any extra keyword arguments supplied to the decoration call
+        any extra keyword arguments supplied to the decoration call.
+        These will be passed directly to the `before`, `after`,
+        and/or `instead` callables.
 
     :return: the decorated function/method/class
     :rtype: Union[FunctionType,MethodType,type]
@@ -733,7 +466,6 @@ def decorate(
         # Disallow mixing of class-level functionality
         opts["implicit_method_decoration"] = implicit_method_decoration
         opts["instance_methods_only"] = instance_methods_only
-        opts["_use_future_syntax"] = _use_future_syntax
 
     def decorator(decorated):
 
@@ -742,27 +474,17 @@ def decorate(
         if my_instead is not None:
 
             global instead
-            dec_kwargs = _kwargs_from_opts(
-                instead_opts, unpack_extras, extras_key, extras
-            )
-            wrapped = instead(my_instead, **dec_kwargs)(wrapped)
+            wrapped = instead(my_instead, **{**instead_opts, **extras})(wrapped)
 
         if my_before is not None:
 
             global before
-            dec_kwargs = _kwargs_from_opts(
-                before_opts, unpack_extras, extras_key, extras
-            )
-            wrapped = before(my_before, **dec_kwargs)(wrapped)
+            wrapped = before(my_before, **{**before_opts, **extras})(wrapped)
 
         if my_after is not None:
 
             global after
-
-            dec_kwargs = _kwargs_from_opts(
-                after_opts, unpack_extras, extras_key, extras
-            )
-            wrapped = after(my_after, **dec_kwargs)(wrapped)
+            wrapped = after(my_after, **{**after_opts, **extras})(wrapped)
 
         def wrapper(*args, **kwargs):
 
@@ -789,12 +511,9 @@ def construct_decorator(
     instead_opts=None,
     implicit_method_decoration=True,
     instance_methods_only=False,
-    unpack_extras=True,
-    _use_future_syntax=False,
-    extras_key="extras",
     **extras
 ):
-    """Return a custom decorator
+    """Return a custom decorator.
 
     Options are all the same as for :any:`decorate` and are, in fact,
     passed directly to it.
@@ -819,20 +538,5 @@ def construct_decorator(
         instead_opts=instead_opts,
         implicit_method_decoration=implicit_method_decoration,
         instance_methods_only=instance_methods_only,
-        unpack_extras=unpack_extras,
-        extras_key=extras_key,
-        _use_future_syntax=_use_future_syntax,
         **extras
     )
-
-
-def _kwargs_from_opts(opts, unpack_extras, extras_key, extras):
-    kwargs = opts
-    if opts.get("unpack_extras", unpack_extras) or opts.get(
-        "_use_future_syntax", False
-    ):
-        kwargs.update(extras)
-    else:
-        key = opts.get("extras_key", extras_key)
-        kwargs[key] = extras
-    return kwargs

--- a/src/pydecor/decorators/generic.py
+++ b/src/pydecor/decorators/generic.py
@@ -360,9 +360,9 @@ def decorate(
     before=None,
     after=None,
     instead=None,
-    before_opts=None,
-    after_opts=None,
-    instead_opts=None,
+    before_kwargs=None,
+    after_kwargs=None,
+    instead_kwargs=None,
     implicit_method_decoration=True,
     instance_methods_only=False,
     **extras
@@ -372,9 +372,13 @@ def decorate(
     The ``before``, ``after``, and ``instead`` decorators are all
     stackable, but this decorator provides a straightforward interface
     for combining them so that you don't have to worry about
-    decorator precedence. In addition, this decorator ensures that
-    ``instead`` is called *first*, so that it does not replace
-    any desired calls to ``before`` or ``after``.
+    decorator precedence.
+
+    The order the callables are executed in is:
+
+    * before
+    * instead / wrapped function
+    * after
 
     This decorator takes three optional keyword arguments, ``before``,
     ``after``, and ``instead``, each of which may be any callable that
@@ -382,8 +386,8 @@ def decorate(
 
     The provided callables will be invoked with the same default
     call signature as for the individual decorators. Call signatures
-    and other options may be adjusted by passing ``before_opts``,
-    ``after_opts``, and ``instead_opts`` dicts to this decorator,
+    and other options may be adjusted by passing ``before_kwargs``,
+    ``after_kwargs``, and ``instead_kwargs`` dicts to this decorator,
     which will be directly unpacked into the invocation of the
     individual decorators.
 
@@ -416,15 +420,15 @@ def decorate(
         addition, any keyword arguments provided to `before` are passed
         through to the callable.
 
-    :param dict before_opts:
+    :param dict before_kwargs:
         a dictionary of keyword arguments to pass to the ``before``
         decorator. See :any:`before` for supported options.
 
-    :param dict after_opts:
+    :param dict after_kwargs:
         a dictionary of keyword arguments to pass to the ``after``
         decorator. See :any:`after` for supported options.
 
-    :param dict instead_opts:
+    :param dict instead_kwargs:
         a dictionary of keyword arguments to pass to the ``instead``
         decorator. See :any:`instead` for supported options
 
@@ -458,11 +462,11 @@ def decorate(
     my_after = after
     my_instead = instead
 
-    before_opts = before_opts or {}
-    after_opts = after_opts or {}
-    instead_opts = instead_opts or {}
+    before_kwargs = before_kwargs or {}
+    after_kwargs = after_kwargs or {}
+    instead_kwargs = instead_kwargs or {}
 
-    for opts in (before_opts, after_opts, instead_opts):
+    for opts in (before_kwargs, after_kwargs, instead_kwargs):
         # Disallow mixing of class-level functionality
         opts["implicit_method_decoration"] = implicit_method_decoration
         opts["instance_methods_only"] = instance_methods_only
@@ -474,17 +478,19 @@ def decorate(
         if my_instead is not None:
 
             global instead
-            wrapped = instead(my_instead, **{**instead_opts, **extras})(wrapped)
+            wrapped = instead(my_instead, **{**instead_kwargs, **extras})(
+                wrapped
+            )
 
         if my_before is not None:
 
             global before
-            wrapped = before(my_before, **{**before_opts, **extras})(wrapped)
+            wrapped = before(my_before, **{**before_kwargs, **extras})(wrapped)
 
         if my_after is not None:
 
             global after
-            wrapped = after(my_after, **{**after_opts, **extras})(wrapped)
+            wrapped = after(my_after, **{**after_kwargs, **extras})(wrapped)
 
         def wrapper(*args, **kwargs):
 
@@ -506,9 +512,9 @@ def construct_decorator(
     before=None,
     after=None,
     instead=None,
-    before_opts=None,
-    after_opts=None,
-    instead_opts=None,
+    before_kwargs=None,
+    after_kwargs=None,
+    instead_kwargs=None,
     implicit_method_decoration=True,
     instance_methods_only=False,
     **extras
@@ -533,9 +539,9 @@ def construct_decorator(
         before=before,
         after=after,
         instead=instead,
-        before_opts=before_opts,
-        after_opts=after_opts,
-        instead_opts=instead_opts,
+        before_kwargs=before_kwargs,
+        after_kwargs=after_kwargs,
+        instead_kwargs=instead_kwargs,
         implicit_method_decoration=implicit_method_decoration,
         instance_methods_only=instance_methods_only,
         **extras

--- a/src/pydecor/decorators/ready_to_wear.py
+++ b/src/pydecor/decorators/ready_to_wear.py
@@ -139,10 +139,7 @@ def log_call(logger=None, level="info", format_str=LOG_CALL_FMT_STR):
     :rtype: DecoratorType
     """
     return after(
-        functions.log_call,
-        logger=logger,
-        level=level,
-        format_str=format_str,
+        functions.log_call, logger=logger, level=level, format_str=format_str,
     )
 
 
@@ -169,6 +166,4 @@ def memoize(keep=0, cache_class=LRUCache):
 
     :rtype: DecoratorType
     """
-    return instead(
-        functions.memoize, memo=cache_class(keep)
-    )
+    return instead(functions.memoize, memo=cache_class(keep))

--- a/src/pydecor/decorators/ready_to_wear.py
+++ b/src/pydecor/decorators/ready_to_wear.py
@@ -86,7 +86,6 @@ def intercept(
     """
     return instead(
         functions.intercept,
-        _use_future_syntax=True,
         catch=catch,
         reraise=reraise,
         handler=handler,
@@ -141,7 +140,6 @@ def log_call(logger=None, level="info", format_str=LOG_CALL_FMT_STR):
     """
     return after(
         functions.log_call,
-        _use_future_syntax=True,
         logger=logger,
         level=level,
         format_str=format_str,
@@ -172,5 +170,5 @@ def memoize(keep=0, cache_class=LRUCache):
     :rtype: DecoratorType
     """
     return instead(
-        functions.memoize, _use_future_syntax=True, memo=cache_class(keep)
+        functions.memoize, memo=cache_class(keep)
     )

--- a/src/pydecor/functions.py
+++ b/src/pydecor/functions.py
@@ -85,8 +85,9 @@ def log_call(decorated, logger=None, level="info", format_str=LOG_CALL_FMT_STR):
         log level, case-insensitive
     :param format_str: the string to use when formatting the results
     """
+    module = getmodule(decorated.wrapped)
     if logger is None:
-        name = getmodule(decorated.wrapped).__name__
+        name = module.__name__ if module is not None else "__main__"
         logger = getLogger(name)
     log_fn = getattr(logger, level.lower())
     msg = format_str.format(

--- a/tests/decorators/test_export.py
+++ b/tests/decorators/test_export.py
@@ -27,7 +27,7 @@ class TestExport:
     def test_bad_type(self):
         """Passing something with no __module__ attribute is a TypeError."""
         with pytest.raises(TypeError):
-            export("foo")
+            export("foo")  # type: ignore
 
     def test_not_in_modules(self):
         """Calling in a non-imported context is an error."""
@@ -65,7 +65,7 @@ class TestExport:
         exec(module_code, module.__dict__)
 
         imported = importlib.import_module("my_module")
-        assert imported.__all__ == ["exported"]
+        assert imported.__all__ == ["exported"]  # type: ignore
 
     @pytest.mark.usefixtures("reset_modules")
     def test_imported_module_dynamic_append(self):
@@ -91,7 +91,7 @@ class TestExport:
         exec(module_code, module.__dict__)
 
         imported = importlib.import_module("my_module")
-        assert imported.__all__ == ["first", "exported"]
+        assert imported.__all__ == ["first", "exported"]  # type: ignore
 
     @pytest.mark.usefixtures("reset_modules")
     def test_imported_module_dynamic_append_tuple(self):
@@ -117,7 +117,7 @@ class TestExport:
         exec(module_code, module.__dict__)
 
         imported = importlib.import_module("my_module")
-        assert imported.__all__ == ("first", "exported")
+        assert imported.__all__ == ("first", "exported")  # type: ignore
 
     @pytest.mark.usefixtures("reset_modules")
     def test_export_idempotent_already_present(self):
@@ -141,7 +141,7 @@ class TestExport:
         exec(module_code, module.__dict__)
 
         imported = importlib.import_module("my_module")
-        assert imported.__all__ == ["exported"]
+        assert imported.__all__ == ["exported"]  # type: ignore
 
     @pytest.mark.usefixtures("reset_modules")
     def test_export_idempotent_multiple_calls(self):
@@ -164,14 +164,16 @@ class TestExport:
         exec(module_code, module.__dict__)
 
         imported = importlib.import_module("my_module")
-        assert imported.__all__ == ["exported"]
+        assert imported.__all__ == ["exported"]  # type: ignore
 
     @pytest.mark.usefixtures("reset_modules")
     def test_imported_module_static_no_all(self):
         """A module present in imports is manipulated correctly."""
         from .exports import no_all
 
-        assert no_all.__all__ == ["exported"]  # pylint: disable=no-member
+        # pylint: disable=no-member
+        assert no_all.__all__ == ["exported"]  # type: ignore
+        # pylint: enable=no-member
 
     @pytest.mark.usefixtures("reset_modules")
     def test_imported_module_static_list_all(self):
@@ -193,7 +195,7 @@ class TestExport:
         from .exports import class_export
 
         # pylint: disable=no-member
-        assert class_export.__all__ == ["Exported"]
+        assert class_export.__all__ == ["Exported"]  # type: ignore
 
     @pytest.mark.usefixtures("reset_modules")
     def test_imported_module_static_multi_export(self):
@@ -201,7 +203,7 @@ class TestExport:
         from .exports import multi_export
 
         # pylint: disable=no-member
-        assert multi_export.__all__ == ["Exported", "exported"]
+        assert multi_export.__all__ == ["Exported", "exported"]  # type: ignore
 
     @pytest.mark.usefixtures("reset_modules")
     def test_export_class_dynamic(self):
@@ -224,7 +226,7 @@ class TestExport:
         exec(module_code, module.__dict__)
 
         imported = importlib.import_module("my_module")
-        assert imported.__all__ == ["Exported"]
+        assert imported.__all__ == ["Exported"]  # type: ignore
 
     @pytest.mark.usefixtures("reset_modules")
     def test_export_instancemethod_fails(self):

--- a/tests/decorators/test_ready_to_wear.py
+++ b/tests/decorators/test_ready_to_wear.py
@@ -1,0 +1,253 @@
+"""Test ready-to-use decorators."""
+
+import typing as t
+from logging import getLogger
+from time import sleep
+from unittest.mock import Mock, call
+
+import pytest
+
+from pydecor.caches import FIFOCache, LRUCache, TimedCache
+from pydecor.constants import LOG_CALL_FMT_STR
+from pydecor.decorators import (
+    log_call,
+    intercept,
+    memoize,
+)
+
+
+@pytest.mark.parametrize(
+    "raises, catch, reraise, include_handler",
+    [
+        (Exception, Exception, ValueError, False),
+        (Exception, Exception, ValueError, True),
+        (Exception, Exception, True, True),
+        (Exception, Exception, True, False),
+        (None, Exception, ValueError, False),
+        (None, Exception, ValueError, True),
+        (Exception, Exception, None, False),
+        (Exception, Exception, None, True),
+        (Exception, RuntimeError, ValueError, False),  # won't catch
+        (Exception, RuntimeError, ValueError, True),  # won't catch
+    ],
+)
+def test_intercept(raises, catch, reraise, include_handler):
+    """Test the intercept decorator"""
+    wrapped = Mock()
+
+    wrapped.__name__ = str("wrapped")
+
+    if raises is not None:
+        wrapped.side_effect = raises
+
+    handler = Mock(name="handler") if include_handler else None
+
+    if handler is not None:
+        handler.__name__ = str("handler")
+
+    fn = intercept(catch=catch, reraise=reraise, handler=handler)(wrapped)
+
+    will_catch = raises and issubclass(raises, catch)
+
+    if reraise and will_catch:
+        to_be_raised = raises if reraise is True else reraise
+        with pytest.raises(to_be_raised):
+            fn()
+    elif raises and not will_catch:
+        with pytest.raises(raises):
+            fn()
+    else:
+        fn()
+
+    if handler is not None and will_catch:
+        # pylint: disable=unsubscriptable-object
+        called_with = handler.call_args[0][0]
+        # pylint: enable=unsubscriptable-object
+        assert isinstance(called_with, raises)
+
+    if handler is not None and not will_catch:
+        handler.assert_not_called()
+
+    wrapped.assert_called_once_with(*(), **{})
+
+
+def test_log_call():
+    """Test the log_call decorator"""
+    exp_logger = getLogger(__name__)
+    exp_logger.debug = Mock()  # type: ignore
+
+    @log_call(level="debug")
+    def func(*args, **kwargs):
+        return "foo"
+
+    call_args = ("a",)
+    call_kwargs = {"b": "c"}
+
+    call_res = func(*call_args, **call_kwargs)
+
+    exp_msg = LOG_CALL_FMT_STR.format(
+        name="func", args=call_args, kwargs=call_kwargs, result=call_res
+    )
+
+    exp_logger.debug.assert_called_once_with(exp_msg)  # type: ignore
+
+
+class TestMemoization:
+    """Tests for memoization"""
+
+    # (args, kwargs)
+    memoizable_calls: t.Tuple[t.Tuple, ...] = (
+        (("a", "b"), {"c": "d"}),
+        ((["a", "b", "c"],), {"c": "d"}),
+        ((lambda x: "foo",), {"c": lambda y: "bar"}),
+        (({"a": "a"},), {"c": "d"}),
+        ((type(str("A"), (object,), {})(),), {}),
+        ((), {}),
+        ((1, 2, 3), {}),
+    )
+
+    @pytest.mark.parametrize("args, kwargs", memoizable_calls)
+    def test_memoize_basic(self, args, kwargs):
+        """Test basic use of the memoize decorator"""
+        tracker = Mock(return_value="foo")
+
+        @memoize()
+        def func(*args, **kwargs):
+            return tracker(args, kwargs)
+
+        assert func(*args, **kwargs) == "foo"
+        tracker.assert_called_once_with(args, kwargs)
+
+        assert func(*args, **kwargs) == "foo"
+        assert len(tracker.mock_calls) == 1
+
+    def test_memoize_lru(self):
+        """Test removal of least-recently-used items"""
+        call_list = tuple(range(5))  # 0-4
+        tracker = Mock()
+
+        @memoize(keep=5, cache_class=LRUCache)
+        def func(val):
+            tracker(val)
+            return val
+
+        for val in call_list:
+            func(val)
+
+        # LRU: 0 1 2 3 4
+        assert len(tracker.mock_calls) == len(call_list)
+        for val in call_list:
+            assert call(val) in tracker.mock_calls
+
+        # call with all the same args
+        for val in call_list:
+            func(val)
+
+        # no new calls, lru order should be same
+        # LRU: 0 1 2 3 4
+        assert len(tracker.mock_calls) == len(call_list)
+        for val in call_list:
+            assert call(val) in tracker.mock_calls
+
+        # add new value, popping least-recently-used (0)
+        # LRU: 1 2 3 4 5
+        func(5)
+        assert len(tracker.mock_calls) == len(call_list) + 1
+        assert tracker.mock_calls[-1] == call(5)  # most recent call
+
+        # Re-call with 0, asserting that we call the func again,
+        # and dropping 1
+        # LRU: 2 3 4 5 0
+        func(0)
+        assert len(tracker.mock_calls) == len(call_list) + 2
+        assert tracker.mock_calls[-1] == call(0)  # most recent call
+
+        # Let's ensure that using something rearranges it
+        func(2)
+        # LRU: 3 4 5 0 2
+        # no new calls
+        assert len(tracker.mock_calls) == len(call_list) + 2
+        assert tracker.mock_calls[-1] == call(0)  # most recent call
+
+        # Let's put another new value into the cache
+        func(6)
+        # LRU: 4 5 0 2 6
+        assert len(tracker.mock_calls) == len(call_list) + 3
+        assert tracker.mock_calls[-1] == call(6)
+
+        # Assert that 2 hasn't been dropped from the list, like it
+        # would have been if we hadn't called it before 6
+        func(2)
+        # LRU: 4 5 0 6 2
+        assert len(tracker.mock_calls) == len(call_list) + 3
+        assert tracker.mock_calls[-1] == call(6)
+
+    def test_memoize_fifo(self):
+        """Test using the FIFO cache"""
+        call_list = tuple(range(5))  # 0-4
+        tracker = Mock()
+
+        @memoize(keep=5, cache_class=FIFOCache)
+        def func(val):
+            tracker(val)
+            return val
+
+        for val in call_list:
+            func(val)
+
+        # Cache: 0 1 2 3 4
+        assert len(tracker.mock_calls) == len(call_list)
+        for val in call_list:
+            assert call(val) in tracker.mock_calls
+
+        # call with all the same args
+        for val in call_list:
+            func(val)
+
+        # no new calls, cache still the same
+        # Cache: 0 1 2 3 4
+        assert len(tracker.mock_calls) == len(call_list)
+        for val in call_list:
+            assert call(val) in tracker.mock_calls
+
+        # add new value, popping first in (0)
+        # Cache: 1 2 3 4 5
+        func(5)
+        assert len(tracker.mock_calls) == len(call_list) + 1
+        assert tracker.mock_calls[-1] == call(5)  # most recent call
+
+        # Assert 5 doesn't yield a new call
+        func(5)
+        assert len(tracker.mock_calls) == len(call_list) + 1
+        assert tracker.mock_calls[-1] == call(5)  # most recent call
+
+        # Re-call with 0, asserting that we call the func again,
+        # and dropping 1
+        # Cache: 2 3 4 5 0
+        func(0)
+        assert len(tracker.mock_calls) == len(call_list) + 2
+        assert tracker.mock_calls[-1] == call(0)  # most recent call
+
+        # Assert neither 0 nor 5 yield new calls
+        func(0)
+        func(5)
+        assert len(tracker.mock_calls) == len(call_list) + 2
+        assert tracker.mock_calls[-1] == call(0)  # most recent call
+
+    def test_memoization_timed(self):
+        """Test timed memoization"""
+        time = 0.005
+        tracker = Mock()
+
+        @memoize(keep=time, cache_class=TimedCache)
+        def func(val):
+            tracker(val)
+            return val
+
+        assert func(1) == 1
+        assert tracker.mock_calls == [call(1)]
+        assert func(1) == 1
+        assert tracker.mock_calls == [call(1)]
+        sleep(time)
+        assert func(1) == 1
+        assert tracker.mock_calls == [call(1), call(1)]

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -72,7 +72,7 @@ def test_interceptor(raises, catch, reraise, include_handler):
 def test_log_call():
     """Test automatic logging"""
     exp_logger = getLogger(__name__)
-    exp_logger.debug = Mock()
+    exp_logger.debug = Mock()  # type: ignore
 
     def func(*args, **kwargs):
         return "foo"
@@ -88,4 +88,4 @@ def test_log_call():
         name="func", args=call_args, kwargs=call_kwargs, result=call_res
     )
 
-    exp_logger.debug.assert_called_once_with(exp_msg)
+    exp_logger.debug.assert_called_once_with(exp_msg)  # type: ignore

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-envlist = py35, py36, py37, py38, pypy3
+envlist = py36, py37, py38, pypy3
 
 [testenv]
 
 setenv =
   PACKAGE_NAME = pydecor
 
+whitelist_externals =
+  make
+
 commands =
-  pip install -r requirements-dev.txt
-  coverage run --source {env:PACKAGE_NAME:} -m py.test {posargs}
-  coverage report
+  make test


### PR DESCRIPTION
### Additions

* Moves firmly to new call signature for callables passed to generic decorators, which now take a unified `Decorated` instance containing information about `args`, `kwargs`, the `wrapped` insteand, and the `result` of any calls.
* Comprehensive `Makefile` to make contribution easier
* Lots of development tooling: default vscode settings, autoformatting, standard linting, etc.

### Removals

* The old syntax for generic decorators is retired
* In order to enable type annotations and better checking with mypy, Python < 3.6 is not supported.
