### PR TITLE
doc: fix typo that returning correct decorator wrapped function.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ Why PyDecor?
                 return decorated(*args, **kwargs)
             return wrapper
 
-        return decorated
+        return decorator
 
     @auth_decorator(request=requst)
     def some_view():


### PR DESCRIPTION
in the readme, the decorator `auth_decorator` should return function `decorator`, not the `decorated`